### PR TITLE
WIP: show gallery of board/schematic images on github pages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+machine:
+  timezone:
+    America/New_York
+
+dependencies:
+  pre:
+    - pip install git+https://github.com/upverter/schematic-file-converter freetype-py
+
+deployment:
+  production:
+    branch: justin/gallery # TODO: change to master
+    commands:
+      - gallery/update_github_site.sh

--- a/gallery/files/_config.yml
+++ b/gallery/files/_config.yml
@@ -1,0 +1,1 @@
+markdown: kramdown

--- a/gallery/files/_config.yml
+++ b/gallery/files/_config.yml
@@ -1,1 +1,2 @@
 markdown: kramdown
+baseurl: robocup-pcb

--- a/gallery/files/_layouts/main.html
+++ b/gallery/files/_layouts/main.html
@@ -4,7 +4,6 @@ layout: layout
 
 <head>
     <link rel='stylesheet' type='text/css' href='/{{site.baseurl}}/styles.css' />
-    <link rel='stylesheet' type='text/css' href='https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/css/lightbox.min.css' />
 </head>
 
 <body>
@@ -12,11 +11,13 @@ layout: layout
     {{ content }}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox-plus-jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.colorbox/1.6.4/jquery.colorbox-min.js"></script>
 
     <script>
-    $('img').attr('data-lightbox', 'image-1').attr('data-title', 'image 1')
+    // $('img').colorbox({rel:'group1', href='active-pcb/pic.png'});
+    $('img').each(function() {
+        $(this).colorbox({href:this.src})
+    });
     </script>
 
 </body>

--- a/gallery/files/_layouts/main.html
+++ b/gallery/files/_layouts/main.html
@@ -12,11 +12,14 @@ layout: layout
     {{ content }}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox-plus-jquery.min.js"></script>
 
+    <!-- wrap each image in an <a> tag and add enable lightbox -->
     <script>
-    $('img').attr('data-lightbox', 'image-1').attr('data-title', 'image 1')
+    $('img').each(function() {
+        $(this).replaceWith('<a data-lightbox="lbox" href=' + this.src + '>' + '<img src=' + this.src + ' />' + '</a>');
+    })
     </script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox.min.js"></script>
 
 </body>

--- a/gallery/files/_layouts/main.html
+++ b/gallery/files/_layouts/main.html
@@ -4,6 +4,7 @@ layout: layout
 
 <head>
     <link rel='stylesheet' type='text/css' href='/{{site.baseurl}}/styles.css' />
+    <link rel='stylesheet' type='text/css' href='https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/css/lightbox.min.css' />
 </head>
 
 <body>
@@ -11,13 +12,11 @@ layout: layout
     {{ content }}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.colorbox/1.6.4/jquery.colorbox-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox-plus-jquery.min.js"></script>
 
     <script>
-    // $('img').colorbox({rel:'group1', href='active-pcb/pic.png'});
-    $('img').each(function() {
-        $(this).colorbox({href:this.src})
-    });
+    $('img').attr('data-lightbox', 'image-1').attr('data-title', 'image 1')
     </script>
 
 </body>

--- a/gallery/files/_layouts/main.html
+++ b/gallery/files/_layouts/main.html
@@ -2,6 +2,21 @@
 layout: layout
 ---
 
-<link rel='stylesheet' type='text/css' href='/{{site.baseurl}}/styles.css' />
+<head>
+    <link rel='stylesheet' type='text/css' href='/{{site.baseurl}}/styles.css' />
+    <link rel='stylesheet' type='text/css' href='https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/css/lightbox.min.css' />
+</head>
 
-{{ content }}
+<body>
+
+    {{ content }}
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.8.2/js/lightbox-plus-jquery.min.js"></script>
+
+    <script>
+    $('img').attr('data-lightbox', 'image-1').attr('data-title', 'image 1')
+    </script>
+
+</body>

--- a/gallery/files/_layouts/main.html
+++ b/gallery/files/_layouts/main.html
@@ -1,0 +1,7 @@
+---
+layout: layout
+---
+
+<link rel='stylesheet' type='text/css' href='/{{site.baseurl}}/styles.css' />
+
+{{ content }}

--- a/gallery/files/styles.css
+++ b/gallery/files/styles.css
@@ -1,0 +1,3 @@
+img {
+    max-width: 300px;
+}

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -42,20 +42,30 @@ def enumerate_eagle_files(dirpath, exclude=[]):
             if f.endswith('.sch') or f.endswith('.brd'):
                 yield root + '/' + f
 
-# print(list(enumerate_eagle_files('../active-pcb')))
 
-OUTPUT_MDFILE.write("# Images\n")
 
-for filepath in enumerate_eagle_files('../active-pcb'):
-    subpath = filepath[3:]
+def process_file(infile, outdir='out'):
+    subpath = infile[3:]
     print('generating image for file: %s' % subpath)
     try:
         outfile = os.path.join('out', subpath) + '.png'
         generate_image(os.path.join('../', subpath), outfile)
-        OUTPUT_MDFILE.write("# Render\n")
-        OUTPUT_MDFILE.write("![img](%s)\n" % outfile)
-        OUTPUT_MDFILE.write("\n")
+        return outfile
     except Exception as e:
         print('  failed: %s' % subpath)
         # print(e)
 
+
+
+from multiprocessing.pool import ThreadPool
+
+pool = ThreadPool()
+outfiles = pool.map(process_file, enumerate_eagle_files('../active-pcb'))
+
+print(outfile)
+
+
+OUTPUT_MDFILE.write("# Images\n")
+OUTPUT_MDFILE.write("# Render\n")
+OUTPUT_MDFILE.write("![img](%s)\n" % outfile)
+OUTPUT_MDFILE.write("\n")

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -89,11 +89,13 @@ with open(OUTPUT_FILEPATH, 'w') as file:
     file.write("Table of Contents:\n")
     file.write("\n* TOC\n{:toc}\n\n")
     for (outfile, success) in output_files:
+        if not success: continue
         outfile_rel = outfile[len(args.output_dir) + 1:]
         title = os.path.splitext(os.path.basename(outfile))[0]
         file.write("## %s\n" % title)
         file.write("![img](%s)\n" % outfile_rel)
         file.write("\n")
+        break
 
 # done!
 print("\nWrote output file: %s" % OUTPUT_FILEPATH)

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -21,7 +21,7 @@ parser.add_argument("directory",
                     help="Directory containing eagle files")
 args = parser.parse_args()
 
-BASE_DIRECTORY = args.directory
+BASE_DIRECTORY = os.path.abspath(args.directory)
 LOGFILE = open('image-gen.log', 'w')
 
 def mkdir_p(dirname):
@@ -54,8 +54,10 @@ def enumerate_eagle_files(dirpath, exclude=[]):
 
 
 def process_file(infile, outdir='out'):
-    subpath = infile[3:]
-    # print('generating image for file: %s' % subpath)
+    # get filepath relative to @outdir
+    subpath = infile[len(BASE_DIRECTORY) + 1:]
+
+    print('generating image for file: %s' % subpath)
     success = False
     try:
         outfile = os.path.join('out', subpath) + '.png'

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -58,14 +58,10 @@ def process_file(infile, outdir='out'):
 
 
 from multiprocessing.pool import ThreadPool
-
 pool = ThreadPool()
-outfiles = pool.map(process_file, enumerate_eagle_files('../active-pcb'))
-
-print(outfile)
-
-
-OUTPUT_MDFILE.write("# Images\n")
-OUTPUT_MDFILE.write("# Render\n")
-OUTPUT_MDFILE.write("![img](%s)\n" % outfile)
-OUTPUT_MDFILE.write("\n")
+output_files = pool.map(process_file, enumerate_eagle_files('../active-pcb'))
+for outfile in output_files:
+    OUTPUT_MDFILE.write("# Images\n")
+    OUTPUT_MDFILE.write("# Render\n")
+    OUTPUT_MDFILE.write("![img](%s)\n" % outfile)
+    OUTPUT_MDFILE.write("\n")

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -20,22 +20,34 @@ def mkdir_p(dirname):
             raise
 
 
+LOGFILE=open('image-gen.log', 'w')
+
 
 def generate_image(infile, outfile):
+    # print('outfile: %s' % outfile)
     mkdir_p(os.path.dirname(outfile))
+    # print('dirname: %s' % os.path.dirname(outfile))
     proc.check_call(['python2', '-m', 'upconvert.upconverter',
-    '-i', infile, '-t', 'image', '-o', outfile, '-f', 'eaglexml'])
+    '-i', infile, '-t', 'image', '-o', outfile, '-f', 'eaglexml'], stdout=LOGFILE, stderr=LOGFILE)
 
 
+def enumerate_eagle_files(dirpath, exclude=[]):
+    for root, dirs, files in os.walk(dirpath, topdown=True):
+        dirs[:] = [d
+                   for d in dirs
+                   if os.path.abspath(root + '/' + d) not in exclude]
+        for f in files:
+            if f.endswith('.sch') or f.endswith('.brd'):
+                yield root + '/' + f
 
-file_subpaths = [
-    'active-pcb/control-2015-a/control-2015-a.sch'
-]
+# print(list(enumerate_eagle_files('../active-pcb')))
 
 
-for subpath in file_subpaths:
+for filepath in enumerate_eagle_files('../active-pcb'):
+    subpath = filepath[3:]
+    print('generating image for file: %s' % subpath)
     try:
-        generate_image(os.path.join('../', subpath), os.path.join('out', subpath, '.png'))
+        generate_image(os.path.join('../', subpath), os.path.join('out', subpath) + '.png')
     except Exception as e:
-        print('failed: %s' % subpath)
-        print(e)
+        print('  failed: %s' % subpath)
+        # print(e)

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -23,6 +23,8 @@ def mkdir_p(dirname):
 LOGFILE=open('image-gen.log', 'w')
 
 
+OUTPUT_MDFILE=open('output.md', 'w')
+
 def generate_image(infile, outfile):
     # print('outfile: %s' % outfile)
     mkdir_p(os.path.dirname(outfile))
@@ -42,12 +44,18 @@ def enumerate_eagle_files(dirpath, exclude=[]):
 
 # print(list(enumerate_eagle_files('../active-pcb')))
 
+OUTPUT_MDFILE.write("# Images\n")
 
 for filepath in enumerate_eagle_files('../active-pcb'):
     subpath = filepath[3:]
     print('generating image for file: %s' % subpath)
     try:
-        generate_image(os.path.join('../', subpath), os.path.join('out', subpath) + '.png')
+        outfile = os.path.join('out', subpath) + '.png'
+        generate_image(os.path.join('../', subpath), outfile)
+        OUTPUT_MDFILE.write("# Render\n")
+        OUTPUT_MDFILE.write("![img](%s)\n" % outfile)
+        OUTPUT_MDFILE.write("\n")
     except Exception as e:
         print('  failed: %s' % subpath)
         # print(e)
+

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 Generates images from eagle .sch and .brd files and creates a markdown file
 embedding the images.
 """
 
-# install with
+# install Dependencies with
 #   pip2 install git+https://github.com/upverter/schematic-file-converter freetype-py
-import upconvert
 
 import subprocess as proc
 import os
@@ -35,10 +34,8 @@ def mkdir_p(dirname):
 
 
 def generate_image(infile, outfile):
-    # print('outfile: %s' % outfile)
     mkdir_p(os.path.dirname(outfile))
-    # print('dirname: %s' % os.path.dirname(outfile))
-    proc.check_call(['python2', '-m', 'upconvert.upconverter',
+    proc.check_call(['python2', '--unsupported', '-m', 'upconvert.upconverter',
     '-i', infile, '-t', 'image', '-o', outfile, '-f', 'eaglexml'], stdout=LOGFILE, stderr=LOGFILE)
 
 
@@ -56,23 +53,20 @@ def enumerate_eagle_files(dirpath, exclude=[]):
 def process_file(infile, outdir='out'):
     # get filepath relative to @outdir
     subpath = infile[len(BASE_DIRECTORY) + 1:]
-
-    print('generating image for file: %s' % subpath)
     success = False
     try:
         outfile = os.path.join('out', subpath) + '.png'
-        generate_image(os.path.join('../', subpath), outfile)
+        generate_image(infile, outfile)
         print("=> %s" % outfile)
         success = True
     except Exception as e:
         print('  failed: %s' % subpath)
-        # print(e)
+        print(e)
 
     return (outfile, success)
 
 
-print("Generating images for eagle files in directory '%s'" % BASE_DIRECTORY)
-print()
+print("Generating images for eagle files in directory '%s'\n" % BASE_DIRECTORY)
 
 input_files = list(enumerate_eagle_files(BASE_DIRECTORY))
 
@@ -92,5 +86,4 @@ with open(OUTPUT_FILEPATH, 'w') as file:
         file.write("\n")
 
 # done!
-print()
-print("Wrote output file: %s" % OUTPUT_FILEPATH)
+print("\nWrote output file: %s" % OUTPUT_FILEPATH)

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+# install with
+#   pip2 install git+https://github.com/upverter/schematic-file-converter freetype-py
+import upconvert
+import subprocess as proc
+import os
+
+import os
+import errno
+
+# the actual code
+def mkdir_p(dirname):
+    try:
+        os.makedirs(dirname)
+    except OSError as exc: 
+        if exc.errno == errno.EEXIST and os.path.isdir(dirname):
+            pass
+        else:
+            raise
+
+
+
+def generate_image(infile, outfile):
+    mkdir_p(os.path.dirname(outfile))
+    proc.check_call(['python2', '-m', 'upconvert.upconverter',
+    '-i', infile, '-t', 'image', '-o', outfile, '-f', 'eaglexml'])
+
+
+
+file_subpaths = [
+    'active-pcb/control-2015-a/control-2015-a.sch'
+]
+
+
+for subpath in file_subpaths:
+    try:
+        generate_image(os.path.join('../', subpath), os.path.join('out', subpath, '.png'))
+    except Exception as e:
+        print('failed: %s' % subpath)
+        print(e)

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -86,7 +86,8 @@ OUTPUT_FILEPATH=os.path.join(args.output_dir, 'index.md')
 with open(OUTPUT_FILEPATH, 'w') as file:
     # jekyll "front matter"
     file.write("---\ntitle: RoboJackets PCB Gallery\n---\n")
-    file.write("# Images\n\n")
+    file.write("Table of Contents:\n")
+    file.write("\n* TOC\n{:toc}\n\n")
     for (outfile, success) in output_files:
         outfile_rel = outfile[len(args.output_dir) + 1:]
         title = os.path.splitext(os.path.basename(outfile))[0]

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -85,7 +85,7 @@ output_files = pool.map(process_file, input_files)
 OUTPUT_FILEPATH=os.path.join(args.output_dir, 'index.md')
 with open(OUTPUT_FILEPATH, 'w') as file:
     # jekyll "front matter"
-    file.write("---\ntitle: RoboJackets PCB Gallery\n---\n")
+    file.write("---\ntitle: RoboJackets PCB Gallery\nlayout: main\n---\n\n")
     file.write("Table of Contents:\n")
     file.write("\n* TOC\n{:toc}\n\n")
     for (outfile, success) in output_files:
@@ -94,7 +94,6 @@ with open(OUTPUT_FILEPATH, 'w') as file:
         file.write("## %s\n" % title)
         file.write("![img](%s)\n" % outfile_rel)
         file.write("\n")
-        print("OUTFILE REL: %s" % outfile_rel)
 
 # done!
 print("\nWrote output file: %s" % OUTPUT_FILEPATH)

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -95,7 +95,6 @@ with open(OUTPUT_FILEPATH, 'w') as file:
         file.write("## %s\n" % title)
         file.write("![img](%s)\n" % outfile_rel)
         file.write("\n")
-        break
 
 # done!
 print("\nWrote output file: %s" % OUTPUT_FILEPATH)

--- a/gallery/main.py
+++ b/gallery/main.py
@@ -11,12 +11,18 @@ import upconvert
 
 import subprocess as proc
 import os
-
-import os
 import errno
+import argparse
 
-BASE_DIRECTORY="../active-pcb"
-LOGFILE=open('image-gen.log', 'w')
+parser = argparse.ArgumentParser(
+    description="Generate a markdown file containing the renders of all eagle files in a directory")
+parser.add_argument("directory",
+                    type=str,
+                    help="Directory containing eagle files")
+args = parser.parse_args()
+
+BASE_DIRECTORY = args.directory
+LOGFILE = open('image-gen.log', 'w')
 
 def mkdir_p(dirname):
     try:
@@ -63,7 +69,7 @@ def process_file(infile, outdir='out'):
     return (outfile, success)
 
 
-print("Generating images for eagle files in directory '%s' % BASE_DIRECTORY")
+print("Generating images for eagle files in directory '%s'" % BASE_DIRECTORY)
 print()
 
 input_files = list(enumerate_eagle_files(BASE_DIRECTORY))

--- a/gallery/update_github_site.sh
+++ b/gallery/update_github_site.sh
@@ -14,6 +14,9 @@ git checkout gh-pages
 rm -r ./* || true
 popd
 
+# copy gallery static files
+cp $REPO_DIR/gallery/files/* $GALLERY_DIR
+
 # run gallery-generation python script and place output in tmp repo dir
 $REPO_DIR/gallery/main.py $REPO_DIR -o $GALLERY_DIR
 

--- a/gallery/update_github_site.sh
+++ b/gallery/update_github_site.sh
@@ -8,22 +8,25 @@ TMP_DIR=$(mktemp -d)
 GALLERY_DIR=$TMP_DIR/robocup-pcb
 
 # clone repo to tmp dir and checkout gh-pages branch, then remove old content
-git clone $REPO_DIR $GALLERY_DIR
+git clone git@github.com:robojackets/robocup-pcb $GALLERY_DIR --reference $REPO_DIR
 pushd $GALLERY_DIR
 git checkout gh-pages
-rm -r ./*
+rm -r ./* || true
 popd
 
 # run gallery-generation python script and place output in tmp repo dir
 $REPO_DIR/gallery/main.py $REPO_DIR -o $GALLERY_DIR
 
 # set git info
-git config --global user.name "$GIT_USERNAME"
-git config --global user.email "$GIT_EMAIL"
+# git config --global user.name "$GIT_USERNAME"
+# git config --global user.email "$GIT_EMAIL"
 
 # commit and push
 pushd $GALLERY_DIR
 git add .
 git commit -m 'updated pcb gallery'
-git push git@github.com/robojackets/robocup-pcb gh-pages
+git push origin gh-pages
 popd
+
+# cleanup
+# rm -rf $TMP_DIR

--- a/gallery/update_github_site.sh
+++ b/gallery/update_github_site.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+REPO_DIR="./" # TODO: fix - make it point to repo root
+
+TMP_DIR=$(mktemp -d)
+GALLERY_DIR=$TMP_DIR/robocup-pcb
+
+# clone repo to tmp dir and checkout gh-pages branch, then remove old content
+git clone $REPO_DIR $GALLERY_DIR
+pushd $GALLERY_DIR
+git checkout gh-pages
+rm -r ./*
+popd
+
+# run gallery-generation python script and place output in tmp repo dir
+$REPO_DIR/gallery/main.py $REPO_DIR -o $GALLERY_DIR
+
+# set git info
+git config --global user.name "$GIT_USERNAME"
+git config --global user.email "$GIT_EMAIL"
+
+# commit and push
+pushd $GALLERY_DIR
+git add .
+git commit -m 'updated pcb gallery'
+git push git@github.com/robojackets/robocup-pcb gh-pages
+popd

--- a/gallery/update_github_site.sh
+++ b/gallery/update_github_site.sh
@@ -15,7 +15,7 @@ rm -r ./* || true
 popd
 
 # copy gallery static files
-cp $REPO_DIR/gallery/files/* $GALLERY_DIR
+cp -r $REPO_DIR/gallery/files/* $GALLERY_DIR
 
 # run gallery-generation python script and place output in tmp repo dir
 $REPO_DIR/gallery/main.py $REPO_DIR -o $GALLERY_DIR


### PR DESCRIPTION
This PR adds some scripts and a circleci config to automatically generate a github pages site whenever changes are made to the master branch.  It renders all boards/schematics and shows them in a gallery so we can easily preview designs without having to download and open eagle.

TODO:
- [ ] text labels in rendered images don't show up correctly
- [ ] improve webpage header/info
- [ ] show contents hierarchically to reflect folder structure, right now it's a "flat" layout
- [ ] test circleci setup
- [ ] only update pages site for master branch
- [ ] use georgeburdell account to push changes to gh-pages branch
